### PR TITLE
Move HTTPS environment variable for Django to TLS overlay

### DIFF
--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -45,6 +45,8 @@ services:
         - traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https
 
   managair_server:
+    environment:
+      - HTTPS=on
     deploy:
       labels:
         - traefik.http.routers.managair-server.tls=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
       - EMAIL_HOST_PASSWORD_FILE=/run/secrets/smtp_password
       - EMAIL_USE_TLS
       - DEFAULT_FROM_EMAIL
-      - HTTPS=on
     secrets:
       - managair_secret_key
       - sql_password


### PR DESCRIPTION
since the local dev environment cannot support https.