### PR TITLE
Use managair 0.7.1, the update to Django 4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         - traefik.http.services.clair-frontend.loadbalancer.server.port=80
 
   managair_server:
-    image: clairberlin/managair:0.7.0
+    image: clairberlin/managair:0.7.1
     command: python manage.py runserver 0.0.0.0:8888
     depends_on:
       - db
@@ -84,7 +84,7 @@ services:
   ingestair:
     # For now, we use the same managair application that also provides the
     # external endpoints. This simplifies sharing of DB models.
-    image: clairberlin/managair:0.7.0
+    image: clairberlin/managair:0.7.1
     command: python manage.py runserver 0.0.0.0:8888
     networks:
       - backend


### PR DESCRIPTION
The latest managair container contains major updates to all framework libraries and many dependencies. In particular, an update from Django3 to Django4 and an update to Pillow 9, which had a critical security vulnerability in version 8.