### PR TITLE
Remove unused credentials

### DIFF
--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -22,18 +22,8 @@ services:
     configs:
       - source: traefik-conf-v1
         target: /etc/traefik/traefik_conf.yaml
-    secrets:
-      - netcup_api_key
-      - netcup_api_password
-      - netcup_customer_number
     volumes:
       - "certificates:/etc/traefik/acme"
-    environment:
-      - NETCUP_POLLING_INTERVAL=30
-      - NETCUP_PROPAGATION_TIMEOUT=1200
-      - NETCUP_API_KEY_FILE=/run/secrets/netcup_api_key
-      - NETCUP_API_PASSWORD_FILE=/run/secrets/netcup_api_password
-      - NETCUP_CUSTOMER_NUMBER_FILE=/run/secrets/netcup_customer_number
 
   static_frontend:
     deploy:
@@ -63,15 +53,6 @@ services:
         - traefik.http.routers.managair-server.tls=true
         - traefik.http.routers.managair-server.tls.domains[0].main=${CLAIR_DOMAIN}
         - traefik.http.routers.managair-server.tls.certresolver=leresolver
-
-secrets:
-  # The password for the clair-berlin netcup account
-  netcup_api_key:
-    file: secrets/netcup-api-key.txt
-  netcup_api_password:
-    file: secrets/netcup-api-password.txt
-  netcup_customer_number:
-    file: secrets/netcup-customer-number.txt
 
 volumes:
   certificates:

--- a/tools/compose-up.sh
+++ b/tools/compose-up.sh
@@ -4,7 +4,6 @@ ROOT_DIR=`dirname $0`
 . $ROOT_DIR/common.sh
 
 deploy_composition () {
-  docker login
   docker-compose up -d -c $COMPOSE_FILES_DIR/docker-compose.yml $DOCKER_STACK_DEPLOY_ARGS --with-registry-auth $CLAIR_STACK_NAME
   while true; do
     echo_stderr "waiting for services to start..."

--- a/tools/deploy-stack.sh
+++ b/tools/deploy-stack.sh
@@ -4,7 +4,6 @@ ROOT_DIR=`dirname $0`
 . $ROOT_DIR/common.sh
 
 deploy_stack () {
-  docker login
   docker stack deploy -c $COMPOSE_FILES_DIR/docker-compose.yml $DOCKER_STACK_DEPLOY_ARGS --with-registry-auth $CLAIR_STACK_NAME
   while true; do
     echo_stderr "waiting for services to start..."

--- a/tools/update-services.sh
+++ b/tools/update-services.sh
@@ -12,7 +12,6 @@ update_tasks () {
     service_name=$1
     image_name=$2
     test -n "$service_name" && test -n "$image_name" || fail_usage
-    docker login
     docker pull $image_name
     full_service_name=${CLAIR_STACK_NAME}_${service_name}
     docker service update --image $image_name $full_service_name --with-registry-auth


### PR DESCRIPTION
Netcup credentials have been unused since we switched from DNS to TLS challenge for the ACME protocol.

Logging in to the Docker Hub isn't necessary any longer since all our images are publicly available now.